### PR TITLE
Form control is not longer used update to control-label

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -75,7 +75,7 @@ transforms.bootstrapify = function($fields) {
 
     $label.addClass('form-label');
     var $inputContainer = $n.root().find('div');
-    $inputContainer.find(':input').addClass('form-control');
+    $inputContainer.find(':input').addClass('control-label');
 
     $div('.form-group').append($label)
       .append('<div class="form-controls"></div>')

--- a/test/testTransforms.js
+++ b/test/testTransforms.js
@@ -52,7 +52,7 @@ describe('inlinableWufoo html transforms', function() {
       var html = cheerio.load('<ul id="my-id"><li><label for="field1">transformable field name</label><div><input name="field1" /></div></li></ul>').root();
       var transformed = transforms.bootstrapify(html, 'foo');
 
-      expect(transformed.html()).to.equal('<div id="my-id"><div class="form-group"><label for="field1" class="form-label">transformable field name</label><div class="form-controls"><div><input name="field1" class="form-control"></div></div></div></div>');
+      expect(transformed.html()).to.equal('<div id="my-id"><div class="form-group"><label for="field1" class="form-label">transformable field name</label><div class="form-controls"><div><input name="field1" class="control-label"></div></div></div></div>');
     });
 
     it('ignores hidden fields', function() {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Bootstrap no longer uses `form-control` in its styling of horizontal form labels, instead it uses `control-label`, this PR updates this.
#### What tests does this PR have?

Update existing test to look for correct class.
#### What gif best describes how you feel about this work?

![Anchorman](https://media.giphy.com/media/SRGpALDA3i5va/giphy.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
