### PR TITLE
I put the wrong classes on the wrong fields

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -73,13 +73,13 @@ transforms.bootstrapify = function($fields) {
       return;
     }
 
-    $label.addClass('form-label');
+    $label.addClass('control-label col-md-4');
     var $inputContainer = $n.root().find('div');
-    $inputContainer.find(':input').addClass('control-label');
+    $inputContainer.find(':input').addClass('form-control');
 
     $div('.form-group').append($label)
-      .append('<div class="form-controls"></div>')
-      .find('.form-controls')
+      .append('<div class="col-md-3"></div>')
+      .find('.col-md-3')
       .append($inputContainer);
 
     $primaryDiv.append($div.html());

--- a/test/testTransforms.js
+++ b/test/testTransforms.js
@@ -52,7 +52,7 @@ describe('inlinableWufoo html transforms', function() {
       var html = cheerio.load('<ul id="my-id"><li><label for="field1">transformable field name</label><div><input name="field1" /></div></li></ul>').root();
       var transformed = transforms.bootstrapify(html, 'foo');
 
-      expect(transformed.html()).to.equal('<div id="my-id"><div class="form-group"><label for="field1" class="form-label">transformable field name</label><div class="form-controls"><div><input name="field1" class="control-label"></div></div></div></div>');
+      expect(transformed.html()).to.equal('<div id="my-id"><div class="form-group"><label for="field1" class="control-label col-md-4">transformable field name</label><div class="col-md-3"><div><input name="field1" class="form-control"></div></div></div></div>');
     });
 
     it('ignores hidden fields', function() {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
- Fixes the last PR I did
- Adds `control-label` to the label rather than the input
- Utilises Bootstraps grid classes
#### What tests does this PR have?

Updated existing tests
#### How can this be tested?

If you run the tripapp and in your config change the...
`wufoo_survey_url` to `: http://localhost:9595`

Then run this branch using `node server.js`
Then run tripapp locally.
You should be able to see the updated from on the almost done page.
#### Screenshots / Screencast

<img width="969" alt="screen shot 2016-02-24 at 17 21 19" src="https://cloud.githubusercontent.com/assets/778942/13294259/0f22488a-db1b-11e5-9ee7-e9b4c3004972.png">
#### What gif best describes how you feel about this work?

![CHUMP](https://media.giphy.com/media/121lhOzN87QCAw/giphy.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
